### PR TITLE
성능테스트: DAC Query Failures 차트 추가 (#488)

### DIFF
--- a/grafana/etc/grafana/provisioning/dashboards/querypie-dac-k6.json
+++ b/grafana/etc/grafana/provisioning/dashboards/querypie-dac-k6.json
@@ -311,7 +311,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "purple",
+            "fixedColor": "blue",
             "mode": "fixed"
           },
           "custom": {
@@ -364,7 +364,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 12,
         "x": 12,
         "y": 0
@@ -390,18 +390,18 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "irate(k6_query_per_second_total[10s])",
+          "expr": "irate(k6_query_count_total[10s])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "qps",
+          "legendFormat": "queries per second",
           "range": true,
           "refId": "A",
           "useBackend": false
         }
       ],
-      "title": "Query Per Second",
+      "title": "Query Count",
       "type": "timeseries"
     },
     {
@@ -993,10 +993,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 7
       },
       "id": 9,
       "options": {
@@ -1357,7 +1357,7 @@
         "sizing": "auto",
         "valueMode": "color"
       },
-      "pluginVersion": "11.1.3",
+      "pluginVersion": "11.1.4",
       "targets": [
         {
           "datasource": {
@@ -1390,6 +1390,107 @@
       ],
       "title": "Network Traffic Basic",
       "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 4,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 81,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "irate(k6_query_failures_total[10s])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "failures per second",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Query Failures",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -1454,7 +1555,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 18
       },
       "id": 6,
       "options": {
@@ -1495,8 +1596,8 @@
       {
         "current": {
           "selected": false,
-          "text": "prometheus",
-          "value": "ddu439d7c5xc0e"
+          "text": "perf-testing",
+          "value": "perf-testing-datasource-1"
         },
         "hide": 0,
         "includeAll": false,
@@ -1541,8 +1642,8 @@
       {
         "current": {
           "selected": false,
-          "text": "grafana-k6",
-          "value": "grafana-k6"
+          "text": "querypie",
+          "value": "querypie"
         },
         "datasource": {
           "type": "prometheus",
@@ -1583,6 +1684,6 @@
   "timezone": "browser",
   "title": "QueryPie-DAC-k6",
   "uid": "querypie-dac-k6",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/k6-run/k6-run-dac-with-heavy-load.sh
+++ b/k6-run/k6-run-dac-with-heavy-load.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o nounset -o errexit -o errtrace -o pipefail
+set -o xtrace
+
+K6_PROMETHEUS_RW_SERVER_URL=http://host.docker.internal:9090/api/v1/write
+K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true
+K6_PROMETHEUS_RW_TREND_STATS="min,p(25),med,p(75),p(90),p(95),p(99),max"
+
+DOCKER_RUN="docker run --rm -it -v $(pwd):/app \
+  -e K6_PROMETHEUS_RW_SERVER_URL=${K6_PROMETHEUS_RW_SERVER_URL} \
+  -e K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=${K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM} \
+  -e K6_PROMETHEUS_RW_TREND_STATS=${K6_PROMETHEUS_RW_TREND_STATS}"
+
+${DOCKER_RUN} custom-k6 run \
+  --out experimental-prometheus-rw \
+  --stage 0s:0,1s:1,\
+5s:1,10s:60,30s:60,10s:120,30s:120,10s:60,60s:30,5s:1 \
+scripts/dac.js

--- a/k6-run/k6-run-dac-with-light-load.sh
+++ b/k6-run/k6-run-dac-with-light-load.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o nounset -o errexit -o errtrace -o pipefail
+set -o xtrace
+
+K6_PROMETHEUS_RW_SERVER_URL=http://host.docker.internal:9090/api/v1/write
+K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true
+K6_PROMETHEUS_RW_TREND_STATS="min,p(25),med,p(75),p(90),p(95),p(99),max"
+
+DOCKER_RUN="docker run --rm -it -v $(pwd):/app \
+  -e K6_PROMETHEUS_RW_SERVER_URL=${K6_PROMETHEUS_RW_SERVER_URL} \
+  -e K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=${K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM} \
+  -e K6_PROMETHEUS_RW_TREND_STATS=${K6_PROMETHEUS_RW_TREND_STATS}"
+
+${DOCKER_RUN} custom-k6 run \
+  --out experimental-prometheus-rw \
+  --stage 0s:0,1s:1,\
+30s:1,10s:30,30s:30,10s:60,30s:60,10s:30,30s:30,10s:1,\
+30s:1,10s:30,30s:30,10s:1,30s:1,10s:0 \
+scripts/dac.js

--- a/k6-run/scripts/dac.ts
+++ b/k6-run/scripts/dac.ts
@@ -11,8 +11,8 @@ import {Counter, Trend} from "k6/metrics"
 
 // 1. init code (call once per VU)
 
-const queryCount = new Counter("query_per_second");
-const queryFailures = new Counter("failed_queries");
+const queryCount = new Counter("query_count");
+const queryFailures = new Counter("query_failures");
 const queryDuration = new Trend("query_duration", true /* isTime */);
 
 // The second argument is a MySQL connection string, e.g.


### PR DESCRIPTION
## Description
- `querypie-dac-k6` 라는 Grafana dashboard 를 개선하였습니다.
- 실행된 쿼리수를 Query Count 로 표기하고, line 의 index 표시에서 `queries per second` 라고 단위를 표시하였습니다. 차트의 라인을 보라에서 파랑으로 바꾸었습니다.
- 실패한 쿼리수 차트를 추가하였습니다. Query Failures 가 제목이고, `failures per second` 라고 단위를 표시하였습니다. 차트의 라인을 빨강으로 표시하였습니다.
- `dac.ts` 부하 생성 코드에서, Counter metric 의 이름을 변경하였습니다. 이에 따라, Grafana dashboard 에서 시각화하는 metric 의 이름도 바뀌었습니다.
  - query_per_second to query_count.
  - failed_queries to query_failures.
- 높은 부하를 생성하는 `k6-run-dac-with-heavy-load.sh`, 낮은 부하를 생성하는 `k6-run-dac-with-light-load.sh` 를 추가하였습니다.

## Related tickets & links
- N/A

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: `수작업 테스트를 완료하였습니다. 첨부 스크린샷 참조.`
- [ ] I need help with writing tests

## Additional notes

<img width="1691" alt="Screenshot 2024-08-22 at 9 44 59 PM" src="https://github.com/user-attachments/assets/0fbc7e0c-517b-4d93-badd-19dfe08fda59">